### PR TITLE
Fix two bugs, in toPrintFormat and validation

### DIFF
--- a/lib/iban.dart
+++ b/lib/iban.dart
@@ -23,7 +23,7 @@ String electronicFormat(String iban){
 /// Inserts a separator every 4 characters.
 String toPrintFormat(String iban,[String separator = ' ']){
   var every4Chars = new RegExp(r'(.{4})(?!$)');
-  return electronicFormat(iban).replaceAllMapped(every4Chars, (_) => '$_$separator');
+  return electronicFormat(iban).replaceAllMapped(every4Chars, (match) => '${match.group(0)}$separator');
 }
 
 /// Check if an IBAN is valid.

--- a/lib/iban.dart
+++ b/lib/iban.dart
@@ -28,7 +28,7 @@ String toPrintFormat(String iban,[String separator = ' ']){
 
 /// Check if an IBAN is valid.
 bool isValid(String _iban) {
-  if (_iban.isEmpty) return false;
+  if (_iban.length < 2) return false;
   var iban = electronicFormat(_iban);
   var spec = specifications[iban.substring(0,2)];
   return spec != null && spec.isValid(iban);

--- a/test/iban_test.dart
+++ b/test/iban_test.dart
@@ -37,6 +37,9 @@ void main() {
     test('Test non existant country code', () {
       expect(isValid('__12345678'), isFalse);
     });
+    test('Test short IBAN', () {
+      expect(isValid('N'), isFalse);
+    });
   });
   test('Test spacing', () {
     expect(toPrintFormat('NL93RABO4892894109'), equals('NL93 RABO 4892 8941 09'));

--- a/test/iban_test.dart
+++ b/test/iban_test.dart
@@ -38,4 +38,7 @@ void main() {
       expect(isValid('__12345678'), isFalse);
     });
   });
+  test('Test spacing', () {
+    expect(toPrintFormat('NL93RABO4892894109'), equals('NL93 RABO 4892 8941 09'));
+  });
 }


### PR DESCRIPTION
For the IBAN validation bug: 
When an IBAN consists only of one character the substring call fails. This came
to light when continously validating an input form.

For the toPrintFormat bug:
There was no spacing applied to the final string. Instead the string
interpolation called toString on Match leading to a broken result.